### PR TITLE
feat(network): Add `--dataplane` arg for cilium usage

### DIFF
--- a/kina/__init__.py
+++ b/kina/__init__.py
@@ -36,12 +36,22 @@ def cluster_create(
             help="Disable CNI for the AKS clusters. This is useful for testing purposes.",
         ),
     ] = False,
+    network_dataplane: Annotated[
+        str | None,
+        typer.Option(
+            "--network-dataplane",
+            "--dataplane",
+            "-d",
+            help=" Network Dataplane to use. Defaults to None.",
+        ),
+    ] = None,
 ) -> None:
     """Create a new Kina AKS Cluster.
 
     Args:
         locations (str): Azure Locations to create Kubernetes Clusters in, comma separated.
         no_cni (bool): Disable CNI for the AKS clusters. This is useful for testing purposes.
+        network_dataplane (str | None): Network Dataplane to use. Defaults to None.
 
     """
     from kina.azure.kubernetes import configure_network_iam, create_aks_clusters
@@ -85,6 +95,7 @@ def cluster_create(
             virtual_network_names=vnets,
             resource_group_name=rg_name,
             no_cni=no_cni,
+            network_dataplane=network_dataplane,
             rich_progress=progress,
             rich_task=aks_task,
         )

--- a/kina/azure/kubernetes.py
+++ b/kina/azure/kubernetes.py
@@ -38,6 +38,7 @@ def create_aks_clusters(
     virtual_network_names: list[str],
     resource_group_name: str,
     no_cni: bool = False,
+    network_dataplane: str | None = None,
     rich_progress: Progress | None = None,
     rich_task: TaskID | None = None,
 ) -> list[str]:
@@ -49,6 +50,7 @@ def create_aks_clusters(
         virtual_network_names (list[str]): List of virtual network names to create AKS clusters in.
         resource_group_name (str): Name of the resource group to create the AKS clusters in.
         no_cni (bool, optional): Flag to disable CNI. Defaults to False.
+        network_dataplane (str |  None, optional): Network Dataplane to use. Defaults to None.
         rich_progress (Progress | None, optional): Optional Rich Progress instance for progress tracking. Defaults to None.
         rich_task (TaskID | None, optional): Optional task ID for progress tracking. Defaults to None.
 
@@ -96,6 +98,7 @@ def create_aks_clusters(
                 "networkProfile": {
                     "networkPlugin": "none" if no_cni else "azure",
                     "networkPluginMode": None if no_cni else "overlay",
+                    "networkDataplane": network_dataplane,
                     "networkMode": "transparent",
                     "loadBalancerSku": "standard",
                     "podCidr": vnet.tags.get("pod-network"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kina"
-version = "1.1.4"
+version = "1.2.0"
 description = "A simple tool to create ephemeral AKS Clusters"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "azure-mgmt-containerservice"
-version = "34.2.0"
+version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-common" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "isodate" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/cd/0d4eb42b0cfb6ec66b6b6b34b49e62cce7bbd735263f7da7435967eae010/azure_mgmt_containerservice-34.2.0.tar.gz", hash = "sha256:141e05f146f28cd4628a83027d515bd253f3b2f8523be43b9841707118ef5a84", size = 471649 }
+sdist = { url = "https://files.pythonhosted.org/packages/35/09/a640bfdb168a42bb23b588f65a4eba363334c6a8c63b7355dfc13ac539cf/azure_mgmt_containerservice-35.0.0.tar.gz", hash = "sha256:71a149b3d65c2bc5c9c9c7843a11f81c3a1fb61ea187326feaa94ad3cee3dc74", size = 472641 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/fe/0e6a9bc2c480be97cb4a9666abf6110c5998d59c8fec886b64c4c19a95e2/azure_mgmt_containerservice-34.2.0-py3-none-any.whl", hash = "sha256:f655570fcd88ca55045bb4f662eccd9a4e3b074aef42aa1d8153f4d76ad89153", size = 638085 },
+    { url = "https://files.pythonhosted.org/packages/cd/55/543f40788734358fd9947a38f32955ef80416fd8d67e8c35cb790789f626/azure_mgmt_containerservice-35.0.0-py3-none-any.whl", hash = "sha256:171554415da6a5c3cf492c86ae7cd606f2d80b3bf3d1cbf3d28a445018aa54f6", size = 638965 },
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "kina"
-version = "1.1.4"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
@@ -304,16 +304,16 @@ wheels = [
 
 [[package]]
 name = "msal"
-version = "1.32.0"
+version = "1.32.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/5f/ef42ef25fba682e83a8ee326a1a788e60c25affb58d014495349e37bce50/msal-1.32.0.tar.gz", hash = "sha256:5445fe3af1da6be484991a7ab32eaa82461dc2347de105b76af92c610c3335c2", size = 149817 }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/94/e855c8347c181caf5f3f7e0641cfbe09a4275882db4b90f8f525e91bc399/msal-1.32.2.tar.gz", hash = "sha256:81622b1bfcc3bde9146b72cdd240599791e652a69371422d3b4cc907501a6c65", size = 151387 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/5a/2e663ef56a5d89eba962941b267ebe5be8c5ea340a9929d286e2f5fac505/msal-1.32.0-py3-none-any.whl", hash = "sha256:9dbac5384a10bbbf4dae5c7ea0d707d14e087b92c5aa4954b3feaa2d1aa0bcb7", size = 114655 },
+    { url = "https://files.pythonhosted.org/packages/68/b2/466eef0b0447d5ad4319fda63d899b88d04fc4e1bab4630bed3583795b04/msal-1.32.2-py3-none-any.whl", hash = "sha256:2e8cafac9063dd522d4bd5a8ac7f2d5f897d66c72b3953c90a1aa7e570d2b917", size = 115277 },
 ]
 
 [[package]]
@@ -440,18 +440,18 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.1"
+version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/ad/cd3e3465232ec2416ae9b983f27b9e94dc8171d56ac99b345319a9475967/typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff", size = 106633 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/c5/e7a0b0f5ed69f94c8ab7379c599e6036886bffcde609969a5325f47f1332/typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69", size = 45739 },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
 ]


### PR DESCRIPTION
Add a simple `--network-dataplane`, `--dataplane`, and `-d` option for setting the Network Dataplane to `cilium`.